### PR TITLE
Add AbstractKiteModel type to KiteUtils

### DIFF
--- a/data/settings_ram.yaml
+++ b/data/settings_ram.yaml
@@ -92,3 +92,4 @@ environment:
                              # Cabau: 8.5863 m/s * 5.0 = 42.9 m/s
     height_step: 2.0         # use a grid with 2m resolution in z direction                                 [m]
     grid_step:   2.0         # grid resolution in x and y direction                                         [m]               
+    g_earth: 9.81

--- a/src/KiteUtils.jl
+++ b/src/KiteUtils.jl
@@ -57,6 +57,7 @@ export calc_orient_rot, is_right_handed_orthonormal, enu2ned, ned2enu
 export set_data_path, get_data_path, load_settings, copy_settings        # functions for reading and copying parameters
 export se, se_dict, update_settings, wc_settings, fpc_settings, fpp_settings
 export calculate_rotational_inertia
+export AbstractKiteModel
 
 """
     const MyFloat = Float32
@@ -66,6 +67,14 @@ Type used for position components and scalar SysState members.
 const MyFloat   = Float32           # type to use for position components and scalar SysState members  
 const DATA_PATH = ["data"]          # path for log files and other data
 const MVec3     = MVector{3, Float64}
+
+"""
+    abstract type AbstractKiteModel
+
+All kite models must inherit from this type. All methods that are defined on this type must work
+with all kite models, or a specific method has to be defined for the specific kite model. 
+"""
+abstract type AbstractKiteModel end
 
 include("settings.jl")
 include("yaml_utils.jl")

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -300,6 +300,8 @@ $(TYPEDFIELDS)
     height_step           = 0 
     "grid resolution in x and y direction                                           [m]"
     grid_step             = 0
+    "gravitational acceleration"
+    g_earth               = 0
 end
 function Base.getproperty(set::Settings, sym::Symbol)
     if sym == :l_tether


### PR DESCRIPTION
This is useful such that multiple kite model packages can use the same abstract type.
This pull request adds a g_earth field to the settings as well, such that g_earth can be set to zero during the design phase.