### PR TITLE
Fix wind vec

### DIFF
--- a/src/KiteUtils.jl
+++ b/src/KiteUtils.jl
@@ -74,6 +74,7 @@ Type used for position components and scalar SysState members.
 const MyFloat   = Float32           # type to use for position components and scalar SysState members
 const DATA_PATH = ["data"]          # path for log files and other data
 const MVec3     = MVector{3, Float64}
+const SVec3     = SVector{3, Float64}
 
 P = nothing # suppress warning about undefined global variable
 

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -371,9 +371,10 @@ function Base.setproperty!(set::Settings, sym::Symbol, val)
 end
 
 StructTypes.StructType(::Type{Settings}) = StructTypes.Mutable()
-function StructTypes.constructfrom(
-    ::Type{SVec3}, vec::AbstractVector
-)
+function StructTypes.constructfrom(::Type{MVec3}, vec::AbstractVector)
+    MVec3(vec[1], vec[2], vec[3])
+end
+function StructTypes.constructfrom(::Type{SVec3}, vec::AbstractVector)
     SVec3(vec[1], vec[2], vec[3])
 end
 PROJECT::String = "system.yaml"

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -265,7 +265,7 @@ $(TYPEDFIELDS)
     "angle between upwind direction and the east-north plane [deg]"
     upwind_elevation      = 0
     "wind vector at reference height     [m/s]"
-    wind_vec::MVec3       = zeros(MVec3)
+    wind_vec::SVec3 = zeros(SVec3)
     "if true, use wind_vec; if false, use v_wind, upwind_dir and upwind_elevation"
     use_wind_vec::Bool    = false
     "temperature at reference height     [°C]"
@@ -356,6 +356,10 @@ function Base.setproperty!(set::Settings, sym::Symbol, val)
     else
         if val isa Int && (getproperty(set, sym)) isa Float64
             setfield!(set, sym, Float64(val))
+        elseif sym == :wind_vec && !(val isa SVec3) &&
+               val isa AbstractVector
+            setfield!(set, sym,
+                      SVec3(val[1], val[2], val[3]))
         else
             setfield!(set, sym, val)
         end
@@ -367,8 +371,10 @@ function Base.setproperty!(set::Settings, sym::Symbol, val)
 end
 
 StructTypes.StructType(::Type{Settings}) = StructTypes.Mutable()
-function StructTypes.constructfrom(::Type{MVec3}, vec::AbstractVector)
-    MVec3(vec[1], vec[2], vec[3])
+function StructTypes.constructfrom(
+    ::Type{SVec3}, vec::AbstractVector
+)
+    SVec3(vec[1], vec[2], vec[3])
 end
 PROJECT::String = "system.yaml"
 

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -277,7 +277,7 @@ function wind_vec_from_angles(v_wind, upwind_dir, upwind_elevation)
     east  = horizontal * sin(downwind_azimuth)
     north = horizontal * cos(downwind_azimuth)
     up    = -v_wind * sin(upwind_elevation)
-    SVector(east, north, up)
+    SVec3(east, north, up)
 end
 
 """

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -277,7 +277,7 @@ function wind_vec_from_angles(v_wind, upwind_dir, upwind_elevation)
     east  = horizontal * sin(downwind_azimuth)
     north = horizontal * cos(downwind_azimuth)
     up    = -v_wind * sin(upwind_elevation)
-    MVec3(east, north, up)
+    SVector(east, north, up)
 end
 
 """

--- a/test/test-settings.jl
+++ b/test/test-settings.jl
@@ -64,6 +64,7 @@ using KiteUtils, Test, LinearAlgebra
 
     # assigning wind_vec with a plain Vector converts to KiteUtils.SVec3
     set_wv = deepcopy(se())
+    set_wv.use_wind_vec = true
     set_wv.wind_vec = [1.0, 2.0, 3.0]
     @test set_wv.wind_vec isa KiteUtils.SVec3
     @test set_wv.wind_vec == KiteUtils.SVec3(1.0, 2.0, 3.0)

--- a/test/test-settings.jl
+++ b/test/test-settings.jl
@@ -62,15 +62,15 @@ using KiteUtils, Test, LinearAlgebra
     @test norm(se().wind_vec) ≈ se().v_wind  atol=1e-10
     @test se().v_min == 0.1
 
-    # assigning wind_vec with a plain Vector converts to SVec3
+    # assigning wind_vec with a plain Vector converts to KiteUtils.SVec3
     set_wv = deepcopy(se())
     set_wv.wind_vec = [1.0, 2.0, 3.0]
-    @test set_wv.wind_vec isa SVec3
-    @test set_wv.wind_vec == SVec3(1.0, 2.0, 3.0)
-    # assigning with SVec3 works directly
-    set_wv.wind_vec = SVec3(4.0, 5.0, 6.0)
-    @test set_wv.wind_vec == SVec3(4.0, 5.0, 6.0)
-    # mutating wind_vec in-place is not allowed (SVec3 is immutable)
+    @test set_wv.wind_vec isa KiteUtils.SVec3
+    @test set_wv.wind_vec == KiteUtils.SVec3(1.0, 2.0, 3.0)
+    # assigning with KiteUtils.SVec3 works directly
+    set_wv.wind_vec = KiteUtils.SVec3(4.0, 5.0, 6.0)
+    @test set_wv.wind_vec == KiteUtils.SVec3(4.0, 5.0, 6.0)
+    # mutating wind_vec in-place is not allowed (KiteUtils.SVec3 is immutable)
     @test_throws Exception set_wv.wind_vec .= [7.0, 8.0, 9.0]
     @test se_dict()["environment"]["z0"] == se().z0
     set3 = update_settings()

--- a/test/test-settings.jl
+++ b/test/test-settings.jl
@@ -61,6 +61,17 @@ using KiteUtils, Test, LinearAlgebra
     # wind_vec is auto-synced from v_wind/upwind_dir on load
     @test norm(se().wind_vec) ≈ se().v_wind  atol=1e-10
     @test se().v_min == 0.1
+
+    # assigning wind_vec with a plain Vector converts to SVec3
+    set_wv = deepcopy(se())
+    set_wv.wind_vec = [1.0, 2.0, 3.0]
+    @test set_wv.wind_vec isa SVec3
+    @test set_wv.wind_vec == SVec3(1.0, 2.0, 3.0)
+    # assigning with SVec3 works directly
+    set_wv.wind_vec = SVec3(4.0, 5.0, 6.0)
+    @test set_wv.wind_vec == SVec3(4.0, 5.0, 6.0)
+    # mutating wind_vec in-place is not allowed (SVec3 is immutable)
+    @test_throws Exception set_wv.wind_vec .= [7.0, 8.0, 9.0]
     @test se_dict()["environment"]["z0"] == se().z0
     set3 = update_settings()
     @test set3 == se()


### PR DESCRIPTION
Mutating wind_vec in-place should not be possible because then the setproperty override doesn't run, so define and use an SVector for the wind vec.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
